### PR TITLE
Made AzureRoleAssignments Editable.

### DIFF
--- a/azuredevops/azurerbac/azurerbac/task.json
+++ b/azuredevops/azurerbac/azurerbac/task.json
@@ -54,7 +54,10 @@
       "label": "Azure Role Assignment",
       "type": "pickList",
       "required": true,
-      "helpMarkDown": "The assignment to add or remove"
+      "helpMarkDown": "The assignment to add or remove",
+	  "properties": {
+        "EditableOptions": "True"
+      }
     },
     {
       "name": "usergroup",


### PR DESCRIPTION
Made AzureRoleAssignments Editable. This is needed when the subscription is set by a variable.