### PR TITLE
removing null assignment of capacities variable

### DIFF
--- a/azuredevops/powerbiactions-new/powerbiactionsnew/ps_modules/PowerBi/powerbi.psm1
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/ps_modules/PowerBi/powerbi.psm1
@@ -887,7 +887,6 @@ Function Get-PowerBICapacity {
     $result = Invoke-API -Url $capacityUrl -Method "Get" -Verbose
     $capacities = $result.value
 
-    $capacities = $null;
     if (-not [string]::IsNullOrEmpty($CapacityName)) {
 
         Write-Verbose "Trying to find capacity: $CapacityName"


### PR DESCRIPTION
Removing null assignment of capacity variable. Was causing capacities to be wiped after the initial api call. Reference: #303 