### PR TITLE
Added support for setting dataset permissions

### DIFF
--- a/azuredevops/powerbiactions-new/powerbiactionsnew/run.ps1
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/run.ps1
@@ -89,6 +89,8 @@ PROCESS {
 		$CrossWorkspaceRebinding = Get-VstsInput -Name CrossWorkspaceRebinding -AsBool
 		$ReportWorkspaceName = Get-VstsInput -Name ReportWorkspaceName
 		$tabularEditorArguments = Get-VstsInput -Name TabularEditorArguments
+		$principalType = Get-VstsInput -Name PrincipalType
+		$datasetAccessRight = Get-VstsInput -Name DatasetAccessRight
 
 		$individual = $false
 		if($individualString -eq "Individual"){
@@ -265,6 +267,34 @@ PROCESS {
 			Write-Debug "Tabular Editor Args          : $($tabularEditorArguments)"
 			Publish-TabularEditor -WorkspaceName $workspaceName -FilePattern $filePattern -TabularEditorArguments $tabularEditorArguments
 		}
+		elseif($action -eq "SetDatasetPermissions"){
+			Write-Debug "Users								: $($users)"
+			Write-Debug "Group Ids						: $($groupObjectIds)"
+			Write-Debug "Dataset Name					: $($dataset)"
+			Write-Debug "Principal Type				: $($principalType)"
+			Write-Debug "Permissions					: $($datasetAccessRight)"
+
+			if ($principalType -eq "User") {
+				if($users -eq "") {        
+					Write-Error "When the Principal Type User is chosen you have to supply User(s)."
+				} else {
+					$users = $users.Split(",")
+
+					Add-PowerBIDatasetPermissions -WorkspaceName $workspaceName -DatasetName $dataset -PrincipalType $principalType -Identifiers $users -AccessRight $datasetAccessRight
+				}
+			}      
+
+			if ($principalType -eq "Group") {
+				if($groupObjectIds -eq "") {
+					Write-Error "When the Principal Type Group is chosen you have to supply Group Object Id(s)."
+				}
+				else {
+					$groups = $groupObjectIds.Split(",")      
+
+					Add-PowerBIDatasetPermissions -WorkspaceName $workspaceName -DatasetName $dataset -PrincipalType $principalType -Identifiers $groups -AccessRight $datasetAccessRight
+				}
+			}          
+		}    
 	}
 	finally {
 		Write-Output "Done processing Power BI Actions"

--- a/azuredevops/powerbiactions-new/powerbiactionsnew/task.json
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "4",
+    "Minor": "5",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.0",
@@ -52,7 +52,8 @@
         "SetCapacity": "Set workspace capacity",
         "RebindReport": "Rebind report",
         "UpdateSqlCreds": "Update SQL credentials",
-        "SetRefreshSchedule" : "Set refresh schedule"
+        "SetRefreshSchedule" : "Set refresh schedule",
+        "SetDatasetPermissions" : "Set dataset permissions"
       }
     },
     {
@@ -134,7 +135,7 @@
       "defaultValue": "",
       "required": true,
       "helpMarkDown": "If you want to add multiple users seperate them with ','.",
-      "visibleRule": "Action = AddUsers"
+      "visibleRule": "Action = AddUsers || Action = SetDatasetPermissions"
     },
     {
       "name": "ServicePrincipals",
@@ -152,7 +153,7 @@
       "defaultValue": "",
       "required": true,
       "helpMarkDown": "If you want to add multiple groups separate the ids with ','.",
-      "visibleRule": "Action = AddGroup"
+      "visibleRule": "Action = AddGroup || Action = SetDatasetPermissions"
     },
     {
       "name": "Scope",
@@ -198,7 +199,7 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "The name of the dataset",
-      "visibleRule": "Action = DataRefresh || Action = UpdateDatasource || Action = SQLDirect || Action = UpdateParameters || Action = TakeOwnership || Action = UpdateGateway || Action = RebindReport || Action = SetRefreshSchedule"
+      "visibleRule": "Action = DataRefresh || Action = UpdateDatasource || Action = SQLDirect || Action = UpdateParameters || Action = TakeOwnership || Action = UpdateGateway || Action = RebindReport || Action = SetRefreshSchedule || Action = SetDatasetPermissions"
     },
     {
       "name": "ReportName",
@@ -340,6 +341,35 @@
       "required": true,
       "helpMarkDown": "Arguments to be provided to the Tabular Editor CLI on deployment, for more info click [here](https://docs.tabulareditor.com/te2/Command-line-Options.html)",
       "visibleRule": "Action = DeployTabularModel"
+    },
+    {
+      "name": "PrincipalType",
+      "type": "picklist",
+      "label": "Principal Type",
+      "defaultValue": "User",
+      "required": true,
+      "helpMarkDown": "The type for setting the permissions",
+      "visibleRule": "Action = SetDatasetPermissions",
+      "options": {
+        "User": "User",
+        "Group": "Group"
+      }
+    },
+    {
+      "name": "DatasetAccessRight",
+      "type": "picklist",
+      "label": "Permission",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Specific permission: None, Read, Build (Explore) and Reshare. More [information](https://docs.microsoft.com/en-us/power-bi/developer/embedded/datasets-permissions).",
+      "visibleRule": "Action = SetDatasetPermissions",
+      "options": {
+        "None": "None",
+        "Read": "Read",
+        "ReadExplore": "Read and Build",
+        "ReadReshare": "Read and Reshare",
+        "ReadReshareExplore": "Read, Reshare and Build"
+      }
     }
   ],
   "execution": {

--- a/azuredevops/powerbiactions-new/readme.md
+++ b/azuredevops/powerbiactions-new/readme.md
@@ -17,6 +17,7 @@ The following tasks can be automated by using this extension:
 * Set a specific capacity for a workplace
 * Rebind Report
 * Set Refresh Schedule
+* Set Dataset Permissions
 
 The following organization types are supported from version 5 and higher:
 

--- a/azuredevops/powerbiactions-new/vss-extension.json
+++ b/azuredevops/powerbiactions-new/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "maikvandergaag-power-bi-actions",
   "name": "Power BI Actions",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "publisher": "maikvandergaag",
   "description": "Build and Release Management tasks for Power BI.",
   "public": true,


### PR DESCRIPTION
We automatically deploy Tabular Models as Datasets in Power BI. In order to be able to use these Datasets from Excel we need to set Permissions on the Dataset level. This change adds support to this lovely extension for setting these permissions.

![image](https://user-images.githubusercontent.com/49064748/174740741-c0e1b389-abfb-4bf4-83fb-2bd03b5b9cf7.png)
