### PR TITLE
Improve error message to point permissions not satisfied

### DIFF
--- a/azuredevops/versioncounter/versioncounter/run-task.ps1
+++ b/azuredevops/versioncounter/versioncounter/run-task.ps1
@@ -110,5 +110,5 @@ if ($buildDef) {
     }
 }
 else {
-    Write-Error "Unable to find a build definition for Project $($ProjectName) with the build id: $($buildId)."
+    Write-Error "Unable to find a build definition for Project $($ProjectName) with the build id: $($buildId) or the permissions are not satisfied."
 }


### PR DESCRIPTION
Hi,

I started using the extension with the OAuth authorization and got the error that the build id is incorrect. I suggest updating the error message that points to the permissions are not satisfied.