### PR TITLE
Update Privacy Level Parameter in Power BI Action - Resolves #501

### DIFF
--- a/azuredevops/powerbiactions-new/powerbiactionsnew/ps_modules/PowerBi/powerbi.psm1
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/ps_modules/PowerBi/powerbi.psm1
@@ -1016,19 +1016,13 @@ function Update-BasicSQLDataSourceCredentials{
         [parameter(Mandatory = $true)]$ReportName,
         [Parameter(Mandatory=$true)]$Username,
         [Parameter(Mandatory=$true)]$Password,
-        [Parameter(Mandatory=$true)]$Individual
+        [Parameter(Mandatory=$true)]$Scope
     )
 
     $GroupPath = Get-PowerBIGroupPath -WorkspaceName $WorkspaceName -Create $false
     $report = Get-PowerBIReport -GroupPath $GroupPath -ReportName $ReportName -Verbose
 
     $datasources = Get-PowerBiDataSetDataSources -GroupPath $GroupPath -DataSetId $report.DatasetId
-
-    if($Individual){
-        $level =  "Individual"
-    }else {
-        $level = "Organizational"
-    }
 
     foreach ($dataSource in $datasources) {
 
@@ -1049,7 +1043,7 @@ function Update-BasicSQLDataSourceCredentials{
                     "credentials": "{\"credentialData\":[{\"name\":\"username\", \"value\":\"$($FormattedDataSourceUser)\"},{\"name\":\"password\", \"value\":\"$($FormattedDataSourcePassword)\"}]}",
                     "encryptedConnection": "Encrypted",
                     "encryptionAlgorithm": "None",
-                    "privacyLevel": "$($level)"
+                    "privacyLevel": "$($Scope)"
                 }
             }
 "@

--- a/azuredevops/powerbiactions-new/powerbiactionsnew/run.ps1
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/run.ps1
@@ -76,7 +76,7 @@ PROCESS {
 		$datasourceType = Get-VstsInput -Name DatasourceType
 		$updateAll = Get-VstsInput -Name UpdateAll -AsBool
 		$skipReport = Get-VstsInput -Name SkipReport -AsBool
-		$individualString = Get-VstsInput -Name Individual
+		$scope = Get-VstsInput -Name Scope
 		$servicePrincipalString = Get-VstsInput -Name ServicePrincipals
 		$connectionString = Get-VstsInput -Name ConnectionString
 		$ParameterInput = Get-VstsInput -Name ParameterInput
@@ -94,11 +94,7 @@ PROCESS {
 		$datasetPermissionsGroupObjectIds = Get-VstsInput -Name DatasetPermissionsGroupObjectIds
 		$datasetAccessRight = Get-VstsInput -Name DatasetAccessRight
 
-		$individual = $false
-		if($individualString -eq "Individual"){
-			$individual = $true
-		}
-
+		
 		Write-Debug "WorkspaceName         : $($workspaceName)";
 		Write-Debug "Create                : $($Create)";
 
@@ -186,7 +182,7 @@ PROCESS {
 			Update-ConnectionStringDirectQuery -WorkspaceName $workspaceName -DatasetName $dataset -ConnectionString $connectionstring
 		}
 		elseif($action -eq "UpdateSqlCreds"){
-			Update-BasicSQLDataSourceCredentials -WorkspaceName $workspaceName -ReportName $ReportName -Username $userName -Password $password -Individual $individual
+			Update-BasicSQLDataSourceCredentials -WorkspaceName $workspaceName -ReportName $ReportName -Username $userName -Password $password -Scope $scope
 		}
 		elseif ($action -eq "UpdateParameters") {
 			Write-Debug "Dataset               : $($dataset)";

--- a/azuredevops/powerbiactions-new/powerbiactionsnew/task.json
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/task.json
@@ -160,13 +160,15 @@
       "name": "Scope",
       "type": "picklist",
       "label": "Scope",
-      "defaultValue": "Individual",
+      "defaultValue": "Private",
       "required": true,
-      "helpMarkDown": "Individual is used to access entities that belong to the current user. Organization is used to access entities across the entire company. Only Power BI tenant admins are allowed to use.",
+      "helpMarkDown": "Data sources set to Private contain sensitive or confidential information. Visibility can be restricted to authorized users. Data from a private data source won't fold in to other data sources, including other private data sources. Data sources set to Organizational can fold in to private and other organizational data sources. They can't fold in to public data sources. Visibility is set to a trusted group. Files, internet data sources, and workbook data can be set to Public. Data can fold in to other data sources. Visibility is available to everyone.",
       "visibleRule": "Action = UpdateSqlCreds",
       "options": {
-        "Individual": "Individual",
-        "Organization": "Organization"
+        "Public": "Public",
+        "Organizational": "Organizational",
+        "Private": "Private",
+        "None": "None"
       }
     },
     {


### PR DESCRIPTION
This PR addresses an issue (Issue [#501)](https://github.com/maikvandergaag/msft-extensions/issues/501) with the privacy level parameter in the Power BI Action Update SQL Credentials. The current implementation uses an ‘individual’ parameter with the values “Individual” and “Organization”, which seems to be a misinterpretation of the intended privacy levels.

According to the Microsoft Power BI documentation, the `privacyLevel` parameter in the Gateways - Update Datasource endpoint of the Power BI REST API should accept the following values:
- None
- Organizational
- Private
- Public

These values correspond to the privacy levels that can be assigned to credentials. The current implementation incorrectly sets the $level variable to ‘Individual’ regardless of the input, which is not a valid privacy level.

This PR updates the ‘scope’ parameter and the underlying methods to correctly reflect the privacy levels as defined in the Microsoft documentation. This change will ensure that users can accurately set their desired privacy level when updating SQL credentials in Power BI Actions.

Please review and let me know if there are any concerns or questions.