### PR TITLE
Added support to set SQL datasource credentials to a Service Principal

### DIFF
--- a/azuredevops/powerbiactions-new/powerbiactionsnew/ps_modules/PowerBi/powerbi.psm1
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/ps_modules/PowerBi/powerbi.psm1
@@ -1025,36 +1025,7 @@ function Update-BasicSQLDataSourceCredentials{
     $datasources = Get-PowerBiDataSetDataSources -GroupPath $GroupPath -DataSetId $report.DatasetId
 
     foreach ($dataSource in $datasources) {
-
-        #Store the data source id in a variable (for ease of use later)
-        $dataSourceId = $dataSource.DatasourceId
-        #API url for data source
-        $ApiUrl = "gateways/" + $dataSource.GatewayId + "/datasources/" + $dataSourceId
-
-        #Format username and password, replacing escape characters for the body of the request
-        $FormattedDataSourceUser = $UserName.Replace("\", "\\")
-        $FormattedDataSourcePassword = $Password.Replace("\", "\\")
-
-        #Build the request body
-        $ApiRequestBody = @"
-            {
-                "credentialDetails": {
-                    "credentialType": "Basic",
-                    "credentials": "{\"credentialData\":[{\"name\":\"username\", \"value\":\"$($FormattedDataSourceUser)\"},{\"name\":\"password\", \"value\":\"$($FormattedDataSourcePassword)\"}]}",
-                    "encryptedConnection": "Encrypted",
-                    "encryptionAlgorithm": "None",
-                    "privacyLevel": "$($Scope)"
-                }
-            }
-"@
-        #If it's a sql server source, change the username/password
-        if ($dataSource.DatasourceType -eq "Sql") {
-
-            #Update username & password
-            Invoke-PowerBIRestMethod -Url $ApiUrl -Method Patch -Body "$ApiRequestBody"
-
-            Write-Output "Credentials for data source ""$DataSourceId"" successfully updated..." `n
-        }
+        Update-DatasourceCredentialsInGateway -DataSourceId $dataSource.datasourceId -GatewayId $dataSource.gatewayId -PrivacyLevel $Scope -CredentialType "Basic" -Username $Username -Password $Password
     }
 }
 
@@ -1198,6 +1169,110 @@ Function Get-PowerBiDatasetUsers {
   $result = Invoke-API -Url $url -Method "Get" -Verbose
   $users = $result.value
   return $users
+}
+
+Function Set-PowerBIDatasourceCredentials {
+    Param(
+        [parameter(Mandatory = $true)]$WorkspaceName,
+        [parameter(Mandatory = $true)]$DatasetName,
+        # Only SQL support for now but can be extended
+        # You will need other information for some of the other types to unique identify the datasource that is being searched (i.e. "account" for AzureBlobs); see https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-datasources
+        [parameter(Mandatory = $true)][ValidateSet("SQL")]$DatasourceType, 
+        [parameter(Mandatory = $true)]$ServerName,
+        [parameter(Mandatory = $true)]$DatabaseName,
+        # Only ServicePrincipal support for now but can be extended
+        # You will need other information for some of the other types (i.e. "username" for Basic); see https://learn.microsoft.com/en-us/rest/api/power-bi/gateways/update-datasource
+        [parameter(Mandatory = $true)][ValidateSet("ServicePrincipal")]$CredentialType,        
+        [parameter(Mandatory = $true)]$TenantID,
+        [parameter(Mandatory = $true)]$ServicePrincipalID,
+        [parameter(Mandatory = $true)]$ServicePrincipalKey,
+        [parameter(Mandatory = $true)][ValidateSet("Public","Organizational","Private","None")]$Scope
+    )
+
+    # Retrieve workspace
+    Write-Host "Fetching workspace $($WorkspaceName)..." `n
+    $groupPath = Get-PowerBIGroupPath -WorkspaceName $WorkspaceName
+
+    if (!$groupPath) {
+        throw "Could not find workspace"
+    }
+
+    # Retrieve dataset
+    Write-Host "Fetching dataset $($DatasetName)..." `n
+    $dataset = Get-PowerBIDataset -GroupPath $groupPath -Name $DatasetName
+
+    if (!$dataset) {
+        throw "Could not find dataset"
+    }
+    
+    # Retrieve datasource(s)
+    $datasources = $null
+    if($DatasourceType -eq "SQL")
+    {
+        $datasources = Get-PowerBiDataSetDataSources -GroupPath $groupPath -DataSetId $dataset.id | Where-Object {$_.dataSourceType -eq $DatasourceType -and $_.connectionDetails.server -eq $ServerName -and $_.connectionDetails.database -eq $DatabaseName}
+    }
+    # Make sure to extend the options here if you introduce another DatasourceType
+
+    if(!$datasources)
+    {
+        throw "Could not find datasource(s)"
+    }
+
+    foreach ($datasource in $datasources) {
+        if($CredentialType -eq "ServicePrincipal")
+        {        
+            Update-DatasourceCredentialsInGateway -DataSourceId $datasource.datasourceId -GatewayId $datasource.gatewayId -PrivacyLevel $Scope -CredentialType $CredentialType -TenantId $TenantID -ServicePrincipalClientId $ServicePrincipalID -ServicePrincipalSecret $ServicePrincipalKey
+        }
+        # Make sure to extend the options here if you introduce another CredentialType        
+    }
+}
+
+function Update-DatasourceCredentialsInGateway {
+    Param(    
+        [CmdletBinding(DefaultParameterSetName='Basic')]
+        [parameter(Mandatory = $true)]$DatasourceId,
+        [parameter(Mandatory = $true)]$GatewayId,
+        [parameter(Mandatory = $true)]$PrivacyLevel,
+        [parameter(Mandatory = $true)][ValidateSet("ServicePrincipal","Basic")]$CredentialType, 
+        [Parameter(ParameterSetName='Basic', Mandatory=$true)]$Username,
+        [Parameter(ParameterSetName='Basic', Mandatory=$true)]$Password,
+        [Parameter(ParameterSetName='ServicePrincipal', Mandatory=$true)]$TenantId,
+        [Parameter(ParameterSetName='ServicePrincipal', Mandatory=$true)]$ServicePrincipalClientId,
+        [Parameter(ParameterSetName='ServicePrincipal', Mandatory=$true)]$ServicePrincipalSecret
+    )
+
+    $url = "gateways/$GatewayId/datasources/$DatasourceId"
+    
+    $credentials = ""
+    if($CredentialType -eq "ServicePrincipal")
+    {
+        $servicePrincipalSecretFormatted = $ServicePrincipalSecret.Replace("\", "\\")        
+        $credentials = "`"{\`"credentialData\`":[{\`"name\`":\`"tenantId\`",\`"value\`":\`"$TenantId\`"},{\`"name\`":\`"servicePrincipalClientId\`",\`"value\`":\`"$ServicePrincipalClientId\`"},{\`"name\`":\`"servicePrincipalSecret\`",\`"value\`":\`"$servicePrincipalSecretFormatted\`"}]}`""
+    }
+    elseif($CredentialType -eq "Basic")
+    {
+        $usernameFormatted = $Username.Replace("\", "\\")
+        $paswordFormatted = $Password.Replace("\", "\\")        
+        $credentials = "`"{\`"credentialData\`":[{\`"name\`":\`"username\`",\`"value\`":\`"$usernameFormatted\`"},{\`"name\`":\`"password\`",\`"value\`":\`"$paswordFormatted\`"}]}`""
+    }
+
+    #Build the request body
+    $body = @"
+      {
+          "credentialDetails": {
+              "credentialType": "$CredentialType",
+              "credentials": $credentials,
+              "encryptedConnection": "Encrypted",
+              "encryptionAlgorithm": "None",
+              "privacyLevel": "$PrivacyLevel"
+          }
+      }
+"@
+
+    #Update datasource
+    Invoke-PowerBIRestMethod -Url $url -Method "Patch" -Body $body -Verbose
+
+    Write-Output "Credentials for data source $DatasourceId successfully updated..." `n
 }
 
 Export-ModuleMember -Function "*-*"

--- a/azuredevops/powerbiactions-new/powerbiactionsnew/run.ps1
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/run.ps1
@@ -93,6 +93,11 @@ PROCESS {
 		$datasetPermissionsUsers = Get-VstsInput -Name DatasetPermissionsUsers
 		$datasetPermissionsGroupObjectIds = Get-VstsInput -Name DatasetPermissionsGroupObjectIds
 		$datasetAccessRight = Get-VstsInput -Name DatasetAccessRight
+		$serverName = Get-VstsInput -Name Server
+		$databaseName = Get-VstsInput -Name Database
+		$tenantID = Get-VstsInput -Name TenantID		
+		$servicePrincipalID = Get-VstsInput -Name ServicePrincipalID
+		$servicePrincipalKey = Get-VstsInput -Name ServicePrincipalKey
 
 		
 		Write-Debug "WorkspaceName         : $($workspaceName)";
@@ -324,6 +329,19 @@ PROCESS {
 					Add-PowerBIDatasetPermissions -WorkspaceName $workspaceName -DatasetName $dataset -PrincipalType $principalType -Identifiers $groups -AccessRight $datasetAccessRight
 				}
 			}
+		}
+		elseif ($action -eq "SetSQLDatasourceSPCredentials") {
+			Write-Debug "DatasetName         : $($dataset)";			
+			Write-Debug "ServerName          : $($serverName)";
+			Write-Debug "DatabaseName        : $($databaseName)";
+			Write-Debug "TenantID            : $($tenantID)";
+			Write-Debug "ServicePrincipalID  : $($servicePrincipalID)";
+			Write-Debug "ServicePrincipalKey : $($servicePrincipalKey)";
+			Write-Debug "Scope               : $($scope)";
+
+			Write-Host "Trying to set Service Principal credentials of SQL datasource"
+
+			Set-PowerBIDatasourceCredentials -WorkspaceName $workspaceName -DatasetName $dataset -DatasourceType "Sql" -ServerName $serverName -DatabaseName $databaseName -CredentialType "ServicePrincipal" -TenantID $tenantId -ServicePrincipalID $servicePrincipalID -ServicePrincipalKey $servicePrincipalKey -Scope $scope
 		}
 	}
 	finally {

--- a/azuredevops/powerbiactions-new/powerbiactionsnew/task.json
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/task.json
@@ -54,7 +54,8 @@
         "RebindReport": "Rebind report",
         "UpdateSqlCreds": "Update SQL credentials",
         "SetRefreshSchedule" : "Set refresh schedule",
-        "SetDatasetPermissions" : "Set dataset permissions"
+        "SetDatasetPermissions" : "Set dataset permissions",
+        "SetSQLDatasourceSPCredentials ": "Set SQL datasource Service Principal credentials"
       }
     },
     {
@@ -163,7 +164,7 @@
       "defaultValue": "Private",
       "required": true,
       "helpMarkDown": "Data sources set to Private contain sensitive or confidential information. Visibility can be restricted to authorized users. Data from a private data source won't fold in to other data sources, including other private data sources. Data sources set to Organizational can fold in to private and other organizational data sources. They can't fold in to public data sources. Visibility is set to a trusted group. Files, internet data sources, and workbook data can be set to Public. Data can fold in to other data sources. Visibility is available to everyone.",
-      "visibleRule": "Action = UpdateSqlCreds",
+      "visibleRule": "Action = UpdateSqlCreds | Action = SetSQLDatasourceSPCredentials",
       "options": {
         "Public": "Public",
         "Organizational": "Organizational",
@@ -202,7 +203,7 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "The name of the dataset",
-      "visibleRule": "Action = DataRefresh || Action = UpdateDatasource || Action = SQLDirect || Action = UpdateParameters || Action = TakeOwnership || Action = UpdateGateway || Action = BindToGateway || Action = RebindReport || Action = SetRefreshSchedule || Action = SetDatasetPermissions"
+      "visibleRule": "Action = DataRefresh || Action = UpdateDatasource || Action = SQLDirect || Action = UpdateParameters || Action = TakeOwnership || Action = UpdateGateway || Action = BindToGateway || Action = RebindReport || Action = SetRefreshSchedule || Action = SetDatasetPermissions || Action = SetSQLDatasourceSPCredentials"
     },
     {
       "name": "ReportName",
@@ -391,6 +392,51 @@
         "ReadReshare": "Read and Reshare",
         "ReadReshareExplore": "Read, Reshare and Build"
       }
+    },
+    {
+      "name": "Server",
+      "type": "string",
+      "label": "Server",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The name of the server",
+      "visibleRule": "Action = SetSQLDatasourceSPCredentials"
+    },
+    {
+      "name": "Database",
+      "type": "string",
+      "label": "Database",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The name of the database",
+      "visibleRule": "Action = SetSQLDatasourceSPCredentials"
+    },
+    {
+      "name": "TenantID",
+      "type": "string",
+      "label": "Tenant ID",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The id of the Tenant",
+      "visibleRule": "Action = SetSQLDatasourceSPCredentials"
+    },
+    {
+      "name": "ServicePrincipalID",
+      "type": "string",
+      "label": "Service Principal ID",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The id of the Service Principal",
+      "visibleRule": "Action = SetSQLDatasourceSPCredentials"
+    },
+    {
+      "name": "ServicePrincipalKey",
+      "type": "string",
+      "label": "Service Principal Key",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The key of the Service Principal",
+      "visibleRule": "Action = SetSQLDatasourceSPCredentials"
     }
   ],
   "execution": {


### PR DESCRIPTION
Recently, support for Service Principals for certain data sources has been added. You can read more about it [here](https://blog.fabric.microsoft.com/en-gb/blog/service-principal-support-to-connect-to-data-in-dataflow-datamart-dataset-and-dataflow-gen-2?ft=08-2023:date&trk=article-ssr-frontend-pulse_little-text-block).

One of the significant use cases for this feature is with Datasets that derive their data from Synapse Serverless using Import. Currently, we've manually configured Service Principals for this purpose, but now it's also possible to set these Service Principal credentials via the API.

This PR introduces support for setting the credentials of a SQL datasource of a dataset to a Service Principal. Here's what's included:
- Implementation for SQL datasources has been added initially. However, extending this to other supported data sources should be straightforward due to the generic setup. I've included comments with instructions for anyone interested in expanding this functionality.
- I've refactored the Update-BasicSQLDataSourceCredentials method to eliminate code redundancy, as it shares the same API endpoint.

Please let me know if any additional information or testing is required. We're keen to beta-test this feature.