### PR TITLE
Pass parameters when triggering build pipeline

### DIFF
--- a/azuredevops/triggerpipeline-new/triggerpipeline/run-build.ps1
+++ b/azuredevops/triggerpipeline-new/triggerpipeline/run-build.ps1
@@ -60,7 +60,7 @@ if ($BuildDefinitions) {
             }
             sourceBranch = $Branch
             reason = "userCreated"
-            parameters = $Parameters
+            templateParameters = $Parameters
         }
 
         $jsonbody = $Build | ConvertTo-Json -Depth 100


### PR DESCRIPTION
This PR is to be able to pass parameters when running `run-build.ps1`

As per the documentation for run pipeline 7.1 (https://learn.microsoft.com/en-us/rest/api/azure/devops/build/builds/queue?view=azure-devops-rest-7.1) the json body takes `templateParameters`.

As I understand it the API does nothing with the json property in its current version.