### PR TITLE
Fix ReportId and ReportName output variables in PowerBI tasks

### DIFF
--- a/azuredevops/powerbiactions-new/powerbiactionsnew/ps_modules/PowerBi/powerbi.psm1
+++ b/azuredevops/powerbiactions-new/powerbiactionsnew/ps_modules/PowerBi/powerbi.psm1
@@ -655,7 +655,7 @@ Function Import-PowerBIFile {
     $result = Invoke-API -Url $url -Method "Post" -Body $body -ContentType "multipart/form-data; boundary=--$boundary"
 
     $reportId = $result.Id
-    $reportId = $result.Name
+    $reportName = $result.Name
     Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportId]$reportId"
     Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportName]$reportName"
 
@@ -852,7 +852,7 @@ Function Publish-PowerBIFileApi {
             }
             else {
                 $publish = $false
-                Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportName]$(report.name)"
+                Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportName]$($report.name)"
                 Write-Warning "Report already exists"
             }
         }

--- a/azuredevops/powerbiactions-xplat/powerbiactionsxplat/ps_modules/PowerBI/powerbi.psm1
+++ b/azuredevops/powerbiactions-xplat/powerbiactionsxplat/ps_modules/PowerBI/powerbi.psm1
@@ -654,7 +654,7 @@ Function Import-PowerBIFile {
     $result = Invoke-API -Url $url -Method "Post" -Body $body -ContentType "multipart/form-data; boundary=--$boundary"
 
     $reportId = $result.Id
-    $reportId = $result.Name
+    $reportName = $result.Name
     Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportId]$reportId"
     Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportName]$reportName"
 
@@ -850,7 +850,7 @@ Function Publish-PowerBIFileApi {
             }
             else {
                 $publish = $false
-                Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportName]$(report.name)"
+                Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportName]$($report.name)"
                 Write-Warning "Report already exists"
             }
         }


### PR DESCRIPTION
## Summary

Fix three bugs in the `Import-PowerBIFile` and `Publish-PowerBIFileApi` functions that cause the `PowerBIActions.ReportId` and `PowerBIActions.ReportName` output variables to contain incorrect values.

Both **powerbiactions-new** and **powerbiactions-xplat** extensions are affected. The original **powerbiactions** extension does not have these issues.

## Bugs Fixed

### 1. `PowerBIActions.ReportId` contains report Name instead of Id

In `Import-PowerBIFile`, the `$reportId` variable was correctly assigned `$result.Id` but then immediately overwritten with `$result.Name` on the next line:

```powershell
# Before (broken)
$reportId = $result.Id
$reportId = $result.Name    # overwrites the ID with the Name
```

```powershell
# After (fixed)
$reportId = $result.Id
$reportName = $result.Name   # uses a separate variable
```

### 2. `PowerBIActions.ReportName` is always empty

The output variable referenced `$reportName`, which was never defined in the function scope (because the previous line reused `$reportId`). This is resolved by fix #1 above — `$reportName` is now properly assigned.

### 3. Missing `$` in string interpolation in `Publish-PowerBIFileApi`

When a report already exists and overwrite is not enabled, the `ReportName` output variable was set using `$(report.name)` instead of `$($report.name)`, causing PowerShell to try to execute `report.name` as a command rather than accessing the property:

```powershell
# Before (broken)
Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportName]$(report.name)"

# After (fixed)
Write-Host "##vso[task.setvariable variable=PowerBIActions.ReportName]$($report.name)"
```

## Files Changed

- `azuredevops/powerbiactions-new/powerbiactionsnew/ps_modules/PowerBi/powerbi.psm1`
- `azuredevops/powerbiactions-xplat/powerbiactionsxplat/ps_modules/PowerBI/powerbi.psm1`